### PR TITLE
Temporarily bypass cache for iphones

### DIFF
--- a/index.js
+++ b/index.js
@@ -185,8 +185,13 @@ async function handlePost(event) {
   const body = await request.clone().json()
   const { method, id, jsonrpc } = body
 
-  // Don't cache eth block number calls
-  const bypassCache = method === 'eth_blockNumber'
+  // Bypass cache for
+  // * blockNumber calls
+  // * estimateGas calls
+  const bypassCache =
+    method === 'eth_blockNumber' ||
+    method === 'eth_estimateGas'
+
   if (bypassCache) {
     const response = await getOriginResponse(url, event)
     return formatResponse(response, { id })

--- a/index.js
+++ b/index.js
@@ -184,13 +184,16 @@ async function handlePost(event) {
   const cache = caches.default
   const body = await request.clone().json()
   const { method, id, jsonrpc } = body
+  const userAgent = request.headers.get('User-Agent') || '';
 
   // Bypass cache for
   // * blockNumber calls
   // * estimateGas calls
+  // * iPhone devices (temporarily, until the 500 response we are getting is fixed)
   const bypassCache =
     method === 'eth_blockNumber' ||
-    method === 'eth_estimateGas'
+    method === 'eth_estimateGas' ||
+    userAgent.includes('iPhone')
 
   if (bypassCache) {
     const response = await getOriginResponse(url, event)
@@ -198,7 +201,6 @@ async function handlePost(event) {
   }
 
   // Create a cache key based on method, jsonrpc version, and the rest of the body
-  const cacheable = { method, jsonrpc, ...body.params }
   const cacheableBody = JSON.stringify(body.params)
   const hash = await sha256(cacheableBody)
   // Store the URL in cache by adding the body's hash

--- a/wrangler-template.toml
+++ b/wrangler-template.toml
@@ -10,3 +10,4 @@ route = ""
 EDGE_CACHE_TTL = 60
 BROWSER_CACHE_TTL = 0
 PROVIDERS = '["https://some.provider.co/api-key"]'
+PROVIDER_TIMEOUT = 5000


### PR DESCRIPTION
## Description

* Bypass cache when `iPhone` exists in user agent
* Apply changes that were already running in prod

## Testing

Tested by deploying to `https://web3-provider-proxy.audius.workers.dev/` and pointing iphone at that endpoint

## Deployment
Can deploy this to `eth.audius.co` once merged


